### PR TITLE
Create admin on first startup

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -9,4 +9,5 @@ WORKDIR /usr/src/project/app-main   # this folder HAS manage.py now
 ENTRYPOINT ["/bin/sh", "-c"]
 CMD "/usr/src/venvs/app-main/bin/python manage.py migrate --noinput && \
      /usr/src/venvs/app-main/bin/python manage.py collectstatic --noinput && \
+     /usr/src/venvs/app-main/bin/python create_admin.py && \
      exec /usr/src/venvs/app-main/bin/gunicorn pwned_proxy.wsgi:application --bind 0.0.0.0:8000"

--- a/app-main/create_admin.py
+++ b/app-main/create_admin.py
@@ -1,0 +1,24 @@
+import os
+import django
+import random
+import string
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pwned_proxy.settings')
+
+# Setup Django
+django.setup()
+
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+username = os.getenv('DJANGO_SUPERUSER_USERNAME', 'admin')
+email = os.getenv('DJANGO_SUPERUSER_EMAIL', '')
+
+if not User.objects.filter(username=username).exists():
+    password = ''.join(random.SystemRandom().choices(string.ascii_letters + string.digits, k=32))
+    User.objects.create_superuser(username=username, email=email, password=password)
+    print('Created default admin user:', username)
+    print('Password:', password)
+else:
+    print('Default admin already exists: %s' % username)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.9'
+services:
+  pwned-proxy-app:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile.prod
+    container_name: pwned-proxy-app
+    env_file: .env
+    volumes:
+      - static-data:/usr/src/project/staticfiles
+    depends_on:
+      - pwned-proxy-db
+
+  pwned-proxy-nginx:
+    image: nginx:stable-alpine
+    container_name: pwned-proxy-nginx
+    depends_on:
+      - pwned-proxy-app
+    ports:
+      - "80:80"
+      - "81:81"
+    volumes:
+      - .devcontainer/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - static-data:/usr/src/project/staticfiles
+      - .devcontainer/index.html:/usr/share/nginx/html/dummy/index.html:ro
+
+  pwned-proxy-db:
+    image: postgres:16-alpine
+    container_name: pwned-proxy-db
+    env_file: .env
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:
+  static-data:


### PR DESCRIPTION
## Summary
- add script to create default admin user
- update `Dockerfile.prod` to run the script on container start

## Testing
- `python app-main/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
