### PR TITLE
Fix pwned-proxy-app not staying alive

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -5,9 +5,10 @@ FROM dtuait/pwned-proxy-app-main:python-3.13-bullseye-django-5.1.6-myversion-1.0
 COPY . /usr/src/project
 WORKDIR /usr/src/project/app-main   # this folder HAS manage.py now
 
-# Collect static + migrate every time the container starts
-ENTRYPOINT ["/bin/sh", "-c"]
-CMD "/usr/src/venvs/app-main/bin/python manage.py migrate --noinput && \
-     /usr/src/venvs/app-main/bin/python manage.py collectstatic --noinput && \
-     /usr/src/venvs/app-main/bin/python create_admin.py && \
-     exec /usr/src/venvs/app-main/bin/gunicorn pwned_proxy.wsgi:application --bind 0.0.0.0:8000"
+# Copy entrypoint script and run it at container start
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Start the Django app via the entrypoint script
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       context: .
       dockerfile: .devcontainer/Dockerfile.prod
     env_file: .env
+    expose:
+      - "8000"
     volumes:
       - static-data:/usr/src/project/staticfiles
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+/usr/src/venvs/app-main/bin/python manage.py migrate --noinput
+/usr/src/venvs/app-main/bin/python manage.py collectstatic --noinput
+/usr/src/venvs/app-main/bin/python create_admin.py
+
+exec /usr/src/venvs/app-main/bin/gunicorn pwned_proxy.wsgi:application --bind 0.0.0.0:8000
+


### PR DESCRIPTION
## Summary
- add entrypoint script that runs migrations and starts gunicorn
- update production Dockerfile to use entrypoint script
- expose the gunicorn port in docker-compose

## Testing
- `git status --short`