### PR TITLE
Allow using env password for default admin

### DIFF
--- a/app-main/create_admin.py
+++ b/app-main/create_admin.py
@@ -14,9 +14,13 @@ User = get_user_model()
 
 username = os.getenv('DJANGO_SUPERUSER_USERNAME', 'admin')
 email = os.getenv('DJANGO_SUPERUSER_EMAIL', '')
+password = os.getenv('DJANGO_SUPERUSER_PASSWORD')
 
 if not User.objects.filter(username=username).exists():
-    password = ''.join(random.SystemRandom().choices(string.ascii_letters + string.digits, k=32))
+    if not password:
+        password = ''.join(
+            random.SystemRandom().choices(string.ascii_letters + string.digits, k=32)
+        )
     User.objects.create_superuser(username=username, email=email, password=password)
     print('Created default admin user:', username)
     print('Password:', password)


### PR DESCRIPTION
## Summary
- respect `DJANGO_SUPERUSER_PASSWORD` in the admin creation helper

## Testing
- `python3 -m py_compile app-main/create_admin.py`


------
https://chatgpt.com/codex/tasks/task_e_684fdfbc8be8832c8d14918ef40f6ad2