### PR TITLE
Ensure migrations and admin creation on startup

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -14,7 +14,8 @@ services:
     entrypoint: /bin/sh                         # use BusyBox sh
     # command: -c "/usr/src/venvs/app-main/bin/python manage.py migrate --noinput && /usr/src/venvs/app-main/bin/python manage.py collectstatic --noinput && exec /usr/src/venvs/app-main/bin/gunicorn pwned_proxy.wsgi:application --bind 0.0.0.0:8000"
 
-    command: -c "while :; do sleep 3600; done"
+    # Automatically apply migrations and create the default admin user
+    command: -c "/usr/src/venvs/app-main/bin/python manage.py migrate && /usr/src/venvs/app-main/bin/python create_admin.py && while :; do sleep 3600; done"
 
     expose: ["8000"]
     depends_on: [db]


### PR DESCRIPTION
## Summary
- run `manage.py migrate` and `create_admin.py` when the dev container starts

## Testing
- `python3 -m py_compile app-main/create_admin.py`
- `python3 -m py_compile app-main/manage.py`

------
https://chatgpt.com/codex/tasks/task_e_684fe881cfd8832ca4bad7a818ad72ab