### PR TITLE
Fix CORS hosts for local and ngrok

### DIFF
--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -44,6 +44,7 @@ ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
     "dtuaitsoc.ngrok.dev",
+    "api.dtuaitsoc.ngrok.dev",
 ]
 
 
@@ -171,6 +172,8 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 CSRF_TRUSTED_ORIGINS = [
     "https://api.dtuaitsoc.ngrok.dev",
     "https://dtuaitsoc.ngrok.dev",
+    "http://localhost:8000",
+    "http://127.0.0.1:8000",
     # add other domains if necessary
 ]
 


### PR DESCRIPTION
## Summary
- allow `api.dtuaitsoc.ngrok.dev` and local hosts
- permit localhost in `CSRF_TRUSTED_ORIGINS`

## Testing
- `git ls-files '*.py' -z | xargs -0 python3 -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6850024f761c832cadbc9bc7185b3f32