### PR TITLE
Fix Dockerfile permission error

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -7,7 +7,6 @@ WORKDIR /usr/src/project/app-main   # this folder HAS manage.py now
 
 # Copy entrypoint script and run it at container start
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 # Start the Django app via the entrypoint script
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- remove redundant chmod step from Dockerfile.prod

The base image doesn't allow chmod on `/entrypoint.sh`. The `COPY --chmod=0755` line already sets execute permissions, so the extra chmod isn't needed.

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main python manage.py check`
- `PYTHONPATH=app-main python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68500565a874832c8b62adec999d7be2