### PR TITLE
Remove comment from Dockerfile WORKDIR

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -3,7 +3,7 @@ FROM dtuait/pwned-proxy-app-main:python-3.13-bullseye-django-5.1.6-myversion-1.0
 
 # Copy project source into the image
 COPY . /usr/src/project
-WORKDIR /usr/src/project/app-main   # this folder HAS manage.py now
+WORKDIR /usr/src/project/app-main
 
 # Copy entrypoint script and run it at container start
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
## Summary
- fix production build by removing inline comment from `WORKDIR` directive

## Testing
- `python3 manage.py --version` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685006a1d2e4832cb35773cd2cd14836