### PR TITLE
Wait for Postgres before running migrations

### DIFF
--- a/app-main/wait_for_db.py
+++ b/app-main/wait_for_db.py
@@ -1,0 +1,19 @@
+import time
+import os
+import psycopg2
+
+host = os.getenv('POSTGRES_HOST', 'db')
+port = int(os.getenv('POSTGRES_PORT', 5432))
+db = os.getenv('POSTGRES_DB', 'db')
+user = os.getenv('POSTGRES_USER', 'postgres')
+password = os.getenv('POSTGRES_PASSWORD', '')
+
+while True:
+    try:
+        conn = psycopg2.connect(host=host, port=port, dbname=db, user=user, password=password)
+        conn.close()
+        break
+    except psycopg2.OperationalError:
+        print('Waiting for database...', flush=True)
+        time.sleep(1)
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+/usr/src/venvs/app-main/bin/python wait_for_db.py
+
 /usr/src/venvs/app-main/bin/python manage.py migrate --noinput
 /usr/src/venvs/app-main/bin/python manage.py collectstatic --noinput
 /usr/src/venvs/app-main/bin/python create_admin.py


### PR DESCRIPTION
## Summary
- add a small script to poll Postgres until it accepts connections
- call the script from the container entrypoint before running migrations

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850080a1f78832cb0a763c9620fe8be