### PR TITLE
Implement Whitenoise

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -5,6 +5,9 @@ FROM dtuait/pwned-proxy-app-main:python-3.13-bullseye-django-5.1.6-myversion-1.0
 COPY . /usr/src/project
 WORKDIR /usr/src/project/app-main
 
+# Install any additional Python dependencies (like whitenoise)
+RUN /usr/src/venvs/app-main/bin/pip install --no-cache-dir -r ../.devcontainer/requirements.txt
+
 # Copy entrypoint script and run it at container start
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh
 

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -19,3 +19,4 @@ termcolor==2.5.0
 uritemplate==4.1.1
 urllib3==2.3.0
 gunicorn==23.0.0
+whitenoise==6.6.0

--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -81,6 +81,7 @@ REST_FRAMEWORK = {
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -161,6 +162,7 @@ USE_TZ = True
 
 STATIC_URL = 'static/'
 STATIC_ROOT = BASE_DIR / 'staticfiles'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary
- serve static files with Whitenoise
- install Whitenoise dependencies during Docker build

## Testing
- `docker compose build --no-cache app` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685009253448832cb8214ac9c53a9a18