### PR TITLE
Add Debian deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,45 @@ a superuser is created using the credentials from your `.env` file.
 You can then log into the admin interface at
 `http://localhost:8000/admin/` (or via your ngrok domain) using the
 superuser credentials you provided.
+
+## Deploying on Debian\u00a012
+
+Make sure Docker and Docker Compose are installed:
+
+```bash
+sudo apt update
+sudo apt install docker.io docker-compose -y
+```
+
+Clone this repository and prepare your environment file as described above.
+You can then test the stack with:
+
+```bash
+docker compose up --build --abort-on-container-exit --remove-orphans && \
+docker compose down --volumes --remove-orphans
+```
+
+If everything starts correctly the application will exit once the containers
+are stopped.
+
+## Putting it behind Nginx for HTTPS
+
+Install Nginx on the host and configure it as a reverse proxy:
+
+```nginx
+server {
+    listen 80;
+    server_name example.com;
+
+    location / {
+        proxy_pass http://localhost:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
+Use a tool like `certbot` to obtain TLS certificates and update the
+server block to listen on port `443` with SSL enabled. Once configured,
+requests to `https://example.com` will be forwarded to the Dockerized
+Django application.


### PR DESCRIPTION
## Summary
- document how to deploy on Debian 12
- add reverse proxy guide for nginx

## Testing
- `docker compose config` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500b4b2be0832c957211f77bf94587