### PR TITLE
Fix swagger base URL

### DIFF
--- a/app-main/pwned_proxy/urls.py
+++ b/app-main/pwned_proxy/urls.py
@@ -12,7 +12,6 @@ schema_view = get_schema_view(
     ),
     public=True,
     permission_classes=(permissions.AllowAny,),
-     url='http://localhost:3000',  
 )
 
 urlpatterns = [


### PR DESCRIPTION
## Summary
- remove hardcoded Swagger URL so docs work in production

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `python app-main/manage.py check`
- `python app-main/manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68500e8abfb0832c96de4af217d64530