### PR TITLE
Add proxies for remaining HIBP endpoints

### DIFF
--- a/app-main/api/urls.py
+++ b/app-main/api/urls.py
@@ -11,17 +11,54 @@ from .views import (
     StealerLogsByEmailProxyView,
     StealerLogsByWebsiteDomainProxyView,
     StealerLogsByEmailDomainProxyView,
+    AllBreachesProxyView,
+    SingleBreachProxyView,
+    LatestBreachProxyView,
+    DataClassesProxyView,
+    SubscriptionStatusProxyView,
 )
 
 urlpatterns = [
     # Core
-    path("breached-domain/<str:domain>/", BreachedDomainProxyView.as_view(), name="breached-domain"),
-    path("breached-account/<path:email>/", BreachedAccountProxyView.as_view(), name="breached-account"),
-
+    path(
+        "breached-domain/<str:domain>/",
+        BreachedDomainProxyView.as_view(),
+        name="breached-domain",
+    ),
+    path(
+        "breached-account/<path:email>/",
+        BreachedAccountProxyView.as_view(),
+        name="breached-account",
+    ),
     # Extended
     path("paste-account/", PasteAccountProxyView.as_view(), name="paste-account"),
-    path("subscribed-domains/", SubscribedDomainsProxyView.as_view(), name="subscribed-domains"),
-    path("stealer-logs-email/", StealerLogsByEmailProxyView.as_view(), name="stealer-logs-by-email"),
-    path("stealer-logs-website/", StealerLogsByWebsiteDomainProxyView.as_view(), name="stealer-logs-by-website"),
-    path("stealer-logs-domain/", StealerLogsByEmailDomainProxyView.as_view(), name="stealer-logs-by-email-domain"),
+    path(
+        "subscribed-domains/",
+        SubscribedDomainsProxyView.as_view(),
+        name="subscribed-domains",
+    ),
+    path(
+        "stealer-logs-email/",
+        StealerLogsByEmailProxyView.as_view(),
+        name="stealer-logs-by-email",
+    ),
+    path(
+        "stealer-logs-website/",
+        StealerLogsByWebsiteDomainProxyView.as_view(),
+        name="stealer-logs-by-website",
+    ),
+    path(
+        "stealer-logs-domain/",
+        StealerLogsByEmailDomainProxyView.as_view(),
+        name="stealer-logs-by-email-domain",
+    ),
+    path("breaches/", AllBreachesProxyView.as_view(), name="breaches"),
+    path("breach/<str:name>/", SingleBreachProxyView.as_view(), name="single-breach"),
+    path("latest-breach/", LatestBreachProxyView.as_view(), name="latest-breach"),
+    path("data-classes/", DataClassesProxyView.as_view(), name="data-classes"),
+    path(
+        "subscription-status/",
+        SubscriptionStatusProxyView.as_view(),
+        name="subscription-status",
+    ),
 ]


### PR DESCRIPTION
## Summary
- proxy additional endpoints from HIBP v3, including breaches, single breach, latest breach, data classes and subscription status
- expose new routes in the API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68500f9d879c832c8d197b2f793e46e0