### PR TITLE
Add example API key seed file and extend endpoint tests

### DIFF
--- a/app-main/api/tests.py
+++ b/app-main/api/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/app-main/api/tests/__init__.py
+++ b/app-main/api/tests/__init__.py
@@ -1,0 +1,1 @@
+from .test_urls import *  # noqa

--- a/app-main/api/tests/seeded_api_keys.json.example
+++ b/app-main/api/tests/seeded_api_keys.json.example
@@ -1,0 +1,11 @@
+[
+  {"group_name": "Aalborg Universitet", "raw_key": "example-key-aau", "domains": ["aau.dk"]},
+  {"group_name": "Roskilde Universitet", "raw_key": "example-key-ruc", "domains": ["ruc.dk"]},
+  {"group_name": "Københavns Universitet", "raw_key": "example-key-ku", "domains": ["ku.dk"]},
+  {"group_name": "Niels Bohr Institutet", "raw_key": "example-key-nbi", "domains": ["nbi.dk"]},
+  {"group_name": "IT-Universitetet i København", "raw_key": "example-key-itu", "domains": ["itu.dk"]},
+  {"group_name": "Danmarks Tekniske Universitet", "raw_key": "example-key-dtu", "domains": ["dtu.dk"]},
+  {"group_name": "Danish e-Infrastructure Cooperation", "raw_key": "example-key-deic", "domains": ["deic.dk"]},
+  {"group_name": "Danish e-Infrastructure Cooperation", "raw_key": "example-key-cert", "domains": ["cert.dk"]},
+  {"group_name": "Copenhagen Business School", "raw_key": "example-key-cbs", "domains": ["cbs.dk"]}
+]

--- a/app-main/api/tests/test_urls.py
+++ b/app-main/api/tests/test_urls.py
@@ -1,0 +1,26 @@
+from django.test import SimpleTestCase
+from django.urls import reverse, resolve
+
+from api import views
+
+class URLPatternsTest(SimpleTestCase):
+    def test_all_endpoints_resolve(self):
+        tests = [
+            ("breached-domain", {"domain": "dtu.dk"}, views.BreachedDomainProxyView),
+            ("breached-account", {"email": "user@dtu.dk"}, views.BreachedAccountProxyView),
+            ("paste-account", {}, views.PasteAccountProxyView),
+            ("subscribed-domains", {}, views.SubscribedDomainsProxyView),
+            ("stealer-logs-by-email", {}, views.StealerLogsByEmailProxyView),
+            ("stealer-logs-by-website", {}, views.StealerLogsByWebsiteDomainProxyView),
+            ("stealer-logs-by-email-domain", {}, views.StealerLogsByEmailDomainProxyView),
+            ("breaches", {}, views.AllBreachesProxyView),
+            ("single-breach", {"name": "Example"}, views.SingleBreachProxyView),
+            ("latest-breach", {}, views.LatestBreachProxyView),
+            ("data-classes", {}, views.DataClassesProxyView),
+            ("subscription-status", {}, views.SubscriptionStatusProxyView),
+        ]
+        for name, kwargs, view in tests:
+            with self.subTest(name=name):
+                url = reverse(name, kwargs=kwargs)
+                resolver = resolve(url)
+                self.assertEqual(resolver.func.view_class, view)


### PR DESCRIPTION
## Summary
- move api tests into a package
- add a sample `seeded_api_keys.json.example`
- check all API endpoint URLs resolve to the correct views

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main python manage.py test api -v 2`

------
https://chatgpt.com/codex/tasks/task_e_685014d275a4832c8dd8efbbea4cfe07