### PR TITLE
Fix envutils import in container

### DIFF
--- a/app-main/manage.py
+++ b/app-main/manage.py
@@ -2,6 +2,13 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from pathlib import Path
+
+# When this script is executed inside the Docker image the working
+# directory is ``app-main`` which means modules located in the project
+# root are not on ``sys.path``. Add the parent directory so that the
+# ``envutils`` module can be imported by ``pwned_proxy.settings``.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 
 def main():

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,12 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
+from pathlib import Path
+
+# When using Docker the working directory might not be the project root
+# (e.g. ``app-main``). Include the parent directory on ``sys.path`` so
+# that ``envutils`` can be imported by ``pwned_proxy.settings``.
+sys.path.append(str(Path(__file__).resolve().parent))
 
 
 def main():


### PR DESCRIPTION
## Summary
- add project root to `sys.path` in manage scripts

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68501989e880832c84a22990826e2019