### PR TITLE
Fix envutils import in devcontainer init

### DIFF
--- a/app-main/create_admin.py
+++ b/app-main/create_admin.py
@@ -1,7 +1,14 @@
 import os
+import sys
 import django
 import random
 import string
+from pathlib import Path
+
+# When executed inside Docker the working directory is ``app-main``.
+# Include the parent directory on ``sys.path`` so that ``envutils`` can be
+# imported by ``pwned_proxy.settings``.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pwned_proxy.settings')
 


### PR DESCRIPTION
## Summary
- fix path handling in `create_admin.py` so it can find `envutils`

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.test_settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68501fb2a49c832c9e86bceedacfb513