### PR TITLE
Fix collectstatic permission error

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -11,6 +11,10 @@ RUN /usr/src/venvs/app-main/bin/pip install --no-cache-dir -r ../.devcontainer/r
 # Copy entrypoint script and run it at container start
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh
 
+# Ensure the staticfiles directory exists with write permissions. This allows
+# collectstatic to succeed when the container runs as a non-root user.
+RUN install -d -m 0755 /usr/src/project/app-main/staticfiles
+
 # Start the Django app via the entrypoint script
 ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
## Summary
- ensure `staticfiles` directory exists inside the production image

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.test_settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68502023679c832c9fb75369033d2431