### PR TITLE
Fix directory creation in Docker build

### DIFF
--- a/.devcontainer/Dockerfile.prod
+++ b/.devcontainer/Dockerfile.prod
@@ -11,9 +11,13 @@ RUN /usr/src/venvs/app-main/bin/pip install --no-cache-dir -r ../.devcontainer/r
 # Copy entrypoint script and run it at container start
 COPY --chmod=0755 entrypoint.sh /entrypoint.sh
 
-# Ensure the staticfiles directory exists with write permissions. This allows
-# collectstatic to succeed when the container runs as a non-root user.
-RUN install -d -m 0755 /usr/src/project/app-main/staticfiles
+# Ensure the staticfiles directory exists with the correct ownership.
+# The base image runs as the non-root "appuser", so creation must happen as
+# root and then be chowned back.
+USER root
+RUN install -d -m 0755 /usr/src/project/app-main/staticfiles \
+    && chown appuser:appuser /usr/src/project/app-main/staticfiles
+USER appuser
 
 # Start the Django app via the entrypoint script
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- fix staticfiles directory creation by switching to root temporarily

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.test_settings python manage.py test api > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6850235b919c832c8acaa16caeb41cb3