### PR TITLE
Add verbose test output

### DIFF
--- a/app-main/api/tests/test_urls.py
+++ b/app-main/api/tests/test_urls.py
@@ -23,4 +23,5 @@ class URLPatternsTest(SimpleTestCase):
             with self.subTest(name=name):
                 url = reverse(name, kwargs=kwargs)
                 resolver = resolve(url)
+                print(f"Resolved {name} -> {url} -> {resolver.func.view_class.__name__}")
                 self.assertEqual(resolver.func.view_class, view)


### PR DESCRIPTION
## Summary
- log extra details when resolving URLs during tests

## Testing
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.test_settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6850247c9664832ca2edd793ef3de1d3