### PR TITLE
Add GitHub Actions CI for Docker tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Generate environment file
+        run: ./generate_env.sh
+      - name: Build images
+        run: docker compose build
+      - name: Run integration tests
+        run: |
+          docker compose up -d db
+          docker compose run --rm app /usr/src/venvs/app-main/bin/python manage.py test
+      - name: Shutdown
+        if: always()
+        run: docker compose down -v

--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.test_settings \
 python manage.py test api
 ```
 
+## Running integration tests with Docker Compose
+
+Integration tests can be executed inside the Docker environment. This
+spins up the PostgreSQL service and runs the Django test suite inside the
+`app` container.
+
+```bash
+./generate_env.sh
+docker compose build
+docker compose up -d db
+docker compose run --rm app /usr/src/venvs/app-main/bin/python manage.py test
+docker compose down -v
+```
+
 ## Deploying on Debian\u00a012
 
 Make sure Docker and Docker Compose are installed:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using Docker Compose
- document how to run integration tests locally with Compose

## Testing
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python3 manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6850265c935c832cb171ef4b761eab83