### PR TITLE
Fix envutils import in WSGI

### DIFF
--- a/app-main/pwned_proxy/wsgi.py
+++ b/app-main/pwned_proxy/wsgi.py
@@ -8,6 +8,13 @@ https://docs.djangoproject.com/en/5.1/howto/deployment/wsgi/
 """
 
 import os
+import sys
+from pathlib import Path
+
+# When executed inside Docker the working directory is ``app-main``.
+# Include the parent directory on ``sys.path`` so that ``envutils`` can be
+# imported by ``pwned_proxy.settings``.
+sys.path.append(str(Path(__file__).resolve().parent.parent))
 
 from django.core.wsgi import get_wsgi_application
 


### PR DESCRIPTION
## Summary
- ensure the parent directory is on `sys.path` in `pwned_proxy/wsgi.py`

## Testing
- `python app-main/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685027afaab8832c8860d4feb62f611d