### PR TITLE
Fix README test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ is located at `app-main/api/tests/seeded_api_keys.json`.
 Execute the tests with:
 
 ```bash
-PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.test_settings \
+# Install dependencies if running outside Docker
+pip install -r .devcontainer/requirements.txt
+
+PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings \
 python manage.py test api
 ```
 


### PR DESCRIPTION
## Summary
- fix README test section to use `pwned_proxy.settings`
- mention installing requirements when running locally

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_6850276cf3c8832c9c85e01c7f86b46c