### PR TITLE
Fix wsgi import path

### DIFF
--- a/app-main/pwned_proxy/wsgi.py
+++ b/app-main/pwned_proxy/wsgi.py
@@ -12,9 +12,9 @@ import sys
 from pathlib import Path
 
 # When executed inside Docker the working directory is ``app-main``.
-# Include the parent directory on ``sys.path`` so that ``envutils`` can be
+# Include the repository root on ``sys.path`` so that ``envutils`` can be
 # imported by ``pwned_proxy.settings``.
-sys.path.append(str(Path(__file__).resolve().parent.parent))
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from django.core.wsgi import get_wsgi_application
 


### PR DESCRIPTION
## Summary
- fix sys.path in wsgi module to reach envutils module

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_68591361c12c832cbd0645420d4f48a1