### PR TITLE
Improve env setup feedback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-# They will be randomly generated if not set. You can leave them empty. 
+# Leave these empty to generate secure values automatically when the
+# containers start. The generated values are printed to the console.
 DJANGO_SECRET_KEY=
 POSTGRES_PASSWORD=
 DJANGO_SUPERUSER_USERNAME=

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ immediately.
 
 On first start the application will create a `.env` file with random values
 for the required secrets if none exists.  You can customise these settings by
-creating your own `.env` based on `./env.dev.example` or
-`./env.prod.example`.  A helper script is provided to generate the necessary
+creating your own `.env` based on `./env.example`.  A helper script is provided
+to generate the necessary
 files automatically:
 
 ```bash
@@ -35,9 +35,9 @@ docker compose up --build
 The Django application will be available on port **8000**. It accepts
 requests for both `localhost` and `api.dtuaitsoc.ngrok.dev` thanks to the
 `ALLOWED_HOSTS` configuration. On first start, migrations are applied and a
-superuser is created automatically. If the `.env` file was generated, the
-admin username and password are printed and stored in that file so you can
-reuse them across restarts.
+superuser is created automatically. If the `.env` file was generated, all
+generated values including the admin credentials are printed and stored in that
+file so you can reuse them across restarts.
 
 You can then log into the admin interface at
 `http://localhost:8000/admin/` (or via your ngrok domain) using the

--- a/envutils.py
+++ b/envutils.py
@@ -28,7 +28,9 @@ def ensure_env(base_dir: Path) -> None:
             fh.write(f"{key}={value}\n")
             os.environ.setdefault(key, value)
 
-    print(f"Generated {env_path} with secure defaults")
+    print(f"Generated {env_path} with secure defaults:")
+    for key, value in defaults.items():
+        print(f"  {key}={value}")
     print("Admin credentials:")
     print(f"  username: {defaults['DJANGO_SUPERUSER_USERNAME']}")
     print(f"  password: {defaults['DJANGO_SUPERUSER_PASSWORD']}")


### PR DESCRIPTION
## Summary
- document that env variables are generated from `.env.example`
- update `.env.example` wording
- show generated keys when `.env` is auto-created

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68591aa2dbe0832c9314f5e855800bb5