### PR TITLE
Fix management command import

### DIFF
--- a/app-main/api/management/commands/initial_setup.py
+++ b/app-main/api/management/commands/initial_setup.py
@@ -1,4 +1,5 @@
-from django.core.management.base import BaseCommand, call_command
+from django.core.management.base import BaseCommand
+from django.core.management import call_command
 from django.contrib.auth.models import Group
 from api.models import HIBPKey, APIKey, Domain
 from api.admin import SEED_DATA


### PR DESCRIPTION
## Summary
- fix import of call_command in `initial_setup` management command

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68591da3e500832c98cbe3b41a360dd1