### PR TITLE
Update Coolify compose with HIBP API key support

### DIFF
--- a/docker-compose-coolify.yaml
+++ b/docker-compose-coolify.yaml
@@ -8,6 +8,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DB:-db}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
+      # Optional HIBP API key used for initial setup
+      - HIBP_API_KEY=${HIBP_API_KEY:-}
     expose:
       - "8000"
     depends_on:


### PR DESCRIPTION
## Summary
- add optional `HIBP_API_KEY` variable to `docker-compose-coolify.yaml`

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_685921f06c78832c9c93686a5cf245fe