### PR TITLE
Fix domain access issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ superuser is created automatically. If the `.env` file was generated, all
 generated values including the admin credentials are printed and stored in that
 file so you can reuse them across restarts.
 
+### Using a custom domain
+
+When deploying on platforms like Coolify you may receive a unique domain via
+the `SERVICE_FQDN_APP_8000` environment variable. You can also supply additional
+hosts through `DJANGO_ALLOWED_HOSTS`. These values are automatically appended to
+the Django `ALLOWED_HOSTS` list so the application will accept requests for your
+custom domain.
+
 You can then log into the admin interface at
 `http://localhost:8000/admin/` (or via your ngrok domain) using the
 superuser credentials you provided.

--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -48,6 +48,18 @@ ALLOWED_HOSTS = [
     "api.dtuaitsoc.ngrok.dev",
 ]
 
+# Allow additional hosts to be configured via environment variables.
+# This supports deployments on services like Coolify that provide the
+# domain through SERVICE_FQDN_APP_8000 or a custom DJANGO_ALLOWED_HOSTS
+# variable.
+extra_hosts = os.environ.get("DJANGO_ALLOWED_HOSTS")
+if extra_hosts:
+    ALLOWED_HOSTS += [h.strip() for h in extra_hosts.split(",") if h.strip()]
+
+service_fqdn = os.environ.get("SERVICE_FQDN_APP_8000")
+if service_fqdn:
+    ALLOWED_HOSTS.append(service_fqdn)
+
 
 # Application definition
 


### PR DESCRIPTION
## Summary
- support additional domains via environment variables
- document custom domain usage

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_685922b966d8832caf8ece78f895b231