### PR TITLE
Map coolify domain to default ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,14 @@ superuser is created automatically. If the `.env` file was generated, all
 generated values including the admin credentials are printed and stored in that
 file so you can reuse them across restarts.
 
+When deploying with `docker-compose-coolify.yaml`, ports `80` and `443` are
+mapped to the internal port `8000` so the application is reachable at the
+provided domain without specifying a port.
+
 ### Using a custom domain
 
 When deploying on platforms like Coolify you may receive a unique domain via
-the `SERVICE_FQDN_APP_8000` environment variable. You can also supply additional
+the `SERVICE_FQDN_APP` environment variable. You can also supply additional
 hosts through `DJANGO_ALLOWED_HOSTS`. These values are automatically appended to
 the Django `ALLOWED_HOSTS` list so the application will accept requests for your
 custom domain.

--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -50,13 +50,13 @@ ALLOWED_HOSTS = [
 
 # Allow additional hosts to be configured via environment variables.
 # This supports deployments on services like Coolify that provide the
-# domain through SERVICE_FQDN_APP_8000 or a custom DJANGO_ALLOWED_HOSTS
+# domain through SERVICE_FQDN_APP or a custom DJANGO_ALLOWED_HOSTS
 # variable.
 extra_hosts = os.environ.get("DJANGO_ALLOWED_HOSTS")
 if extra_hosts:
     ALLOWED_HOSTS += [h.strip() for h in extra_hosts.split(",") if h.strip()]
 
-service_fqdn = os.environ.get("SERVICE_FQDN_APP_8000")
+service_fqdn = os.environ.get("SERVICE_FQDN_APP")
 if service_fqdn:
     ALLOWED_HOSTS.append(service_fqdn)
 

--- a/docker-compose-coolify.yaml
+++ b/docker-compose-coolify.yaml
@@ -4,14 +4,15 @@ services:
       context: .
       dockerfile: .devcontainer/Dockerfile.prod
     environment:
-      - SERVICE_FQDN_APP_8000
+      - SERVICE_FQDN_APP
       - POSTGRES_DB=${POSTGRES_DB:-db}
       - POSTGRES_USER=${POSTGRES_USER:-postgres}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:-postgres}
       # Optional HIBP API key used for initial setup
       - HIBP_API_KEY=${HIBP_API_KEY:-}
-    expose:
-      - "8000"
+    ports:
+      - "80:8000"
+      - "443:8000"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- update `docker-compose-coolify.yaml` to publish ports 80 and 443
- rename `SERVICE_FQDN_APP_8000` -> `SERVICE_FQDN_APP`
- document coolify setup in the README

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68592597d828832c94dbff34450fc302