### PR TITLE
Add production domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ docker compose up --build
 ```
 
 The Django application will be available on port **8000**. It accepts
-requests for both `localhost` and `api.dtuaitsoc.ngrok.dev` thanks to the
-`ALLOWED_HOSTS` configuration. On first start, migrations are applied and a
+requests for `localhost`, `api.dtuaitsoc.ngrok.dev` and
+`api.haveibeenpwned.security.ait.dtu.dk` thanks to the `ALLOWED_HOSTS`
+configuration. On first start, migrations are applied and a
 superuser is created automatically. If the `.env` file was generated, all
 generated values including the admin credentials are printed and stored in that
 file so you can reuse them across restarts.

--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -46,6 +46,7 @@ ALLOWED_HOSTS = [
     "127.0.0.1",
     "dtuaitsoc.ngrok.dev",
     "api.dtuaitsoc.ngrok.dev",
+    "api.haveibeenpwned.security.ait.dtu.dk",
 ]
 
 # Allow additional hosts to be configured via environment variables.
@@ -190,6 +191,7 @@ CSRF_TRUSTED_ORIGINS = [
     "http://localhost:8000",
     "http://127.0.0.1:8000",
     # add other domains if necessary
+    "https://api.haveibeenpwned.security.ait.dtu.dk",
 ]
 
 CORS_ALLOW_ALL_ORIGINS = True


### PR DESCRIPTION
## Summary
- allow `api.haveibeenpwned.security.ait.dtu.dk` host
- trust the new domain for CSRF
- mention the domain in README

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_685939110330832c9c6954880252d874