### PR TITLE
Add debug compose for Coolify

### DIFF
--- a/docker-compose-coolify-debug.yaml
+++ b/docker-compose-coolify-debug.yaml
@@ -1,0 +1,48 @@
+services:
+  app:
+    # ─── build the Django image ───────────────────────────────────────────
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile.prod
+
+    # ─── runtime configuration ────────────────────────────────────────────
+    environment:
+      # will be injected by Coolify; useful for Django ALLOWED_HOSTS logic
+      SERVICE_FQDN_APP: ${SERVICE_FQDN_APP}
+      POSTGRES_DB:       ${POSTGRES_DB:-db}
+      POSTGRES_USER:     ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      HIBP_API_KEY:      ${HIBP_API_KEY:-}
+      DJANGO_SETTINGS_MODULE: pwned_proxy.WARNING_import_settings_with_DEBUG_enabled
+
+    depends_on:
+      db:
+        condition: service_healthy
+
+    # tell Traefik which internal port to forward to
+    expose:
+      - "8000"
+
+    labels:
+      - "traefik.enable=true"
+      # make the service discoverable on the port we just exposed
+      - "traefik.http.services.pwnedproxy.loadbalancer.server.port=8000"
+      # Coolify **automatically** creates the router & TLS certificate that
+      # matches the domain you set in the UI, so no extra router label needed
+
+  db:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_DB:       ${POSTGRES_DB:-db}
+      POSTGRES_USER:     ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
- add `docker-compose-coolify-debug.yaml` for easier Coolify deployments with DEBUG enabled

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_68595bb94d9c832c8bca347bc47a2576