### PR TITLE
Add DJANGO_SECRET_KEY support

### DIFF
--- a/docker-compose-coolify-debug.yaml
+++ b/docker-compose-coolify-debug.yaml
@@ -13,6 +13,7 @@ services:
       POSTGRES_USER:     ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       HIBP_API_KEY:      ${HIBP_API_KEY:-}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
       DJANGO_SETTINGS_MODULE: pwned_proxy.WARNING_import_settings_with_DEBUG_enabled
 
     depends_on:

--- a/docker-compose-coolify.yaml
+++ b/docker-compose-coolify.yaml
@@ -13,6 +13,7 @@ services:
       POSTGRES_USER:     ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       HIBP_API_KEY:      ${HIBP_API_KEY:-}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
 
     depends_on:
       db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-db}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
     ports:
       - "8000:8000"
     depends_on:


### PR DESCRIPTION
## Summary
- wire DJANGO_SECRET_KEY into all docker-compose files

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_68595dc8dba4832cad9e35c70a0c8e57