### PR TITLE
Add Coolify secret key env

### DIFF
--- a/docker-compose-coolify.yaml
+++ b/docker-compose-coolify.yaml
@@ -12,6 +12,7 @@ services:
       POSTGRES_DB:       ${POSTGRES_DB:-db}
       POSTGRES_USER:     ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-2YyAbJsncVLgc4cSn6HV6r9PdtwhG5wT}
       HIBP_API_KEY:      ${HIBP_API_KEY:-}
       DJANGO_DEBUG:      ${DJANGO_DEBUG:-false}
 


### PR DESCRIPTION
## Summary
- expose `DJANGO_SECRET_KEY` in `docker-compose-coolify.yaml`

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68596208d4f4832c81cae1514cfc14e0