### PR TITLE
Fix swagger scheme behind proxy

### DIFF
--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -197,3 +197,12 @@ CSRF_TRUSTED_ORIGINS = [
 ]
 
 CORS_ALLOW_ALL_ORIGINS = True
+
+# When running behind a reverse proxy like Traefik the original protocol is
+# communicated via the `X-Forwarded-Proto` header. Without telling Django to
+# trust this header it will assume all requests are HTTP, causing tools like
+# drf-yasg to generate Swagger/OpenAPI URLs with the wrong scheme. Browsers then
+# block these "mixed content" requests. Configure Django to respect the
+# forwarded header so HTTPS links are generated correctly.
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True


### PR DESCRIPTION
## Summary
- correctly detect HTTPS when behind Traefik so Swagger does not reference HTTP

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_685967589078832cac6ac030f01fb744