### PR TITLE
Align proxy endpoints with HIBP

### DIFF
--- a/app-main/api/tests/test_urls.py
+++ b/app-main/api/tests/test_urls.py
@@ -7,12 +7,12 @@ class URLPatternsTest(SimpleTestCase):
     def test_all_endpoints_resolve(self):
         tests = [
             ("breached-domain", {"domain": "dtu.dk"}, views.BreachedDomainProxyView),
-            ("breached-account", {"email": "user@dtu.dk"}, views.BreachedAccountProxyView),
-            ("paste-account", {"email": "user@dtu.dk"}, views.PasteAccountProxyView),
+            ("breached-account", {"account": "user@dtu.dk"}, views.BreachedAccountProxyView),
+            ("paste-account", {"account": "user@dtu.dk"}, views.PasteAccountProxyView),
             ("subscribed-domains", {}, views.SubscribedDomainsProxyView),
-            ("stealer-logs-by-email", {}, views.StealerLogsByEmailProxyView),
-            ("stealer-logs-by-website", {}, views.StealerLogsByWebsiteDomainProxyView),
-            ("stealer-logs-by-email-domain", {}, views.StealerLogsByEmailDomainProxyView),
+            ("stealer-logs-by-email", {"email": "user@dtu.dk"}, views.StealerLogsByEmailProxyView),
+            ("stealer-logs-by-website", {"domain": "dtu.dk"}, views.StealerLogsByWebsiteDomainProxyView),
+            ("stealer-logs-by-email-domain", {"domain": "dtu.dk"}, views.StealerLogsByEmailDomainProxyView),
             ("breaches", {}, views.AllBreachesProxyView),
             ("single-breach", {"name": "Example"}, views.SingleBreachProxyView),
             ("latest-breach", {}, views.LatestBreachProxyView),

--- a/app-main/api/urls.py
+++ b/app-main/api/urls.py
@@ -21,43 +21,43 @@ from .views import (
 urlpatterns = [
     # Core
     path(
-        "breacheddomain/<str:domain>/",
+        "breacheddomain/<str:domain>",
         BreachedDomainProxyView.as_view(),
         name="breached-domain",
     ),
     path(
-        "breachedaccount/<path:email>/",
+        "breachedaccount/<path:account>",
         BreachedAccountProxyView.as_view(),
         name="breached-account",
     ),
     # Extended
-    path("pasteaccount/<path:email>/", PasteAccountProxyView.as_view(), name="paste-account"),
+    path("pasteaccount/<path:account>", PasteAccountProxyView.as_view(), name="paste-account"),
     path(
-        "subscribeddomains/",
+        "subscribeddomains",
         SubscribedDomainsProxyView.as_view(),
         name="subscribed-domains",
     ),
     path(
-        "stealer-logs-email/",
+        "stealerlogsbyemail/<path:email>",
         StealerLogsByEmailProxyView.as_view(),
         name="stealer-logs-by-email",
     ),
     path(
-        "stealer-logs-website/",
+        "stealerlogsbywebsitedomain/<str:domain>",
         StealerLogsByWebsiteDomainProxyView.as_view(),
         name="stealer-logs-by-website",
     ),
     path(
-        "stealer-logs-domain/",
+        "stealerlogsbyemaildomain/<str:domain>",
         StealerLogsByEmailDomainProxyView.as_view(),
         name="stealer-logs-by-email-domain",
     ),
-    path("breaches/", AllBreachesProxyView.as_view(), name="breaches"),
-    path("breach/<str:name>/", SingleBreachProxyView.as_view(), name="single-breach"),
-    path("latestbreach/", LatestBreachProxyView.as_view(), name="latest-breach"),
-    path("dataclasses/", DataClassesProxyView.as_view(), name="data-classes"),
+    path("breaches", AllBreachesProxyView.as_view(), name="breaches"),
+    path("breach/<str:name>", SingleBreachProxyView.as_view(), name="single-breach"),
+    path("latestbreach", LatestBreachProxyView.as_view(), name="latest-breach"),
+    path("dataclasses", DataClassesProxyView.as_view(), name="data-classes"),
     path(
-        "subscription/status/",
+        "subscription/status",
         SubscriptionStatusProxyView.as_view(),
         name="subscription-status",
     ),


### PR DESCRIPTION
## Summary
- match HIBP path style by removing trailing slashes and adjusting parameter names
- document the `hibp-api-key` header instead of `X-API-Key`
- update tests to use the new paths
- use path parameters for stealer log endpoints to match HIBP paths

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`


------
https://chatgpt.com/codex/tasks/task_e_68596a6a4b6c832c9f081ec34ef1d05c