### PR TITLE
Allow embedding in iframes

### DIFF
--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -206,3 +206,8 @@ CORS_ALLOW_ALL_ORIGINS = True
 # forwarded header so HTTPS links are generated correctly.
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 USE_X_FORWARDED_HOST = True
+
+# Allow this application to be embedded in an iframe. By default Django
+# sets the X-Frame-Options header to 'DENY' which prevents embedding. Setting
+# it to 'ALLOWALL' removes the header so the site can be framed by any origin.
+X_FRAME_OPTIONS = 'ALLOWALL'


### PR DESCRIPTION
## Summary
- let the app be embedded in iframes by disabling the `X-Frame-Options` header

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_68596dba4220832ca6b18850d9039e53