### PR TITLE
Invalidate HIBP key cache when updated

### DIFF
--- a/app-main/api/models.py
+++ b/app-main/api/models.py
@@ -119,7 +119,7 @@ class APIKey(models.Model):
 
 from django.db import models
 from django.core.exceptions import ValidationError
-from django.utils import timezone
+from django.core.cache import cache
 
 class HIBPKey(models.Model):
     """
@@ -153,3 +153,8 @@ class HIBPKey(models.Model):
         """
         self.clean()
         super().save(*args, **kwargs)
+        cache.delete("hibp_api_key")
+
+    def delete(self, *args, **kwargs):
+        super().delete(*args, **kwargs)
+        cache.delete("hibp_api_key")


### PR DESCRIPTION
## Summary
- drop unused timezone import
- clear `hibp_api_key` cache when HIBPKey objects are saved or deleted

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_685aad02a868832ca75217dc49e6da40