### PR TITLE
Add env validation check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,20 @@
-# Leave these empty to generate secure values automatically when the
-# containers start. The generated values are printed to the console.
-DJANGO_SECRET_KEY=
-POSTGRES_PASSWORD=
+# Environment configuration for Pwned Proxy
+# Copy this file to `.env` and replace the placeholder values.
+# Generate strong values at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new
+
+# PostgreSQL configuration
+POSTGRES_DB=db
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=<postgres_password>
+
+# Django secret key
+DJANGO_SECRET_KEY=<django_secret_key>
+
+# These can be left empty; startup scripts will handle them
 DJANGO_SUPERUSER_USERNAME=
 DJANGO_SUPERUSER_PASSWORD=
 HIBP_API_KEY=
+SERVICE_FQDN_APP=
+
 # Set to 'true' to enable Django debug mode
-DJANGO_DEBUG=
+DJANGO_DEBUG=false

--- a/README.md
+++ b/README.md
@@ -10,18 +10,19 @@ immediately.
 - [Docker](https://www.docker.com/) and Docker Compose installed
 
 
-On first start the application will create a `.env` file with random values
-for the required secrets if none exists.  You can customise these settings by
-creating your own `.env` based on `./env.example`.  A helper script is provided
-to generate the necessary
-files automatically:
+Before starting the stack you must create a `.env` file. Copy `.env.example`
+and replace the placeholder values. At minimum `DJANGO_SECRET_KEY` and
+`POSTGRES_PASSWORD` need strong values which you can generate at
+<https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new>.
+The `generate_env.sh` helper can create the template files:
 
 ```bash
 ./generate_env.sh
 ```
 
 This populates `.env` and `.devcontainer/.env` using the example templates and
-should be run before starting Docker or the Dev Container.
+should be run before starting Docker or the Dev Container. Edit the created
+files and replace any placeholders.
 
 Set `DJANGO_DEBUG=true` in your `.env` to enable Django's debug mode.
 

--- a/check_env.py
+++ b/check_env.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Validate environment setup before starting the container."""
+from pathlib import Path
+import os
+import sys
+import yaml
+
+BASE_DIR = Path(__file__).resolve().parent
+EXAMPLE = BASE_DIR / '.env.example'
+COMPOSE = BASE_DIR / 'docker-compose-coolify.yaml'
+
+
+def parse_compose(path: Path) -> set[str]:
+    data = yaml.safe_load(path.read_text())
+    envs = set()
+    for svc in data.get('services', {}).values():
+        env = svc.get('environment', {})
+        envs.update(env.keys())
+    return envs
+
+
+def parse_env_example(path: Path) -> dict[str, str]:
+    envs = {}
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        key, _, value = line.partition('=')
+        envs[key] = value
+    return envs
+
+
+def main() -> None:
+    compose_vars = parse_compose(COMPOSE)
+    example_envs = parse_env_example(EXAMPLE)
+
+    missing = compose_vars - example_envs.keys()
+    extra = example_envs.keys() - compose_vars
+    if missing or extra:
+        print('Environment variable mismatch between docker-compose-coolify.yaml and .env.example', file=sys.stderr)
+        if missing:
+            print('Missing in .env.example:', ', '.join(sorted(missing)), file=sys.stderr)
+        if extra:
+            print('Extra in .env.example:', ', '.join(sorted(extra)), file=sys.stderr)
+        sys.exit(1)
+
+    placeholders = {
+        'DJANGO_SECRET_KEY': '<django_secret_key>',
+        'POSTGRES_PASSWORD': '<postgres_password>',
+    }
+
+    for key, placeholder in placeholders.items():
+        value = os.getenv(key)
+        if not value or value == placeholder or (key == 'DJANGO_SECRET_KEY' and value == 'change-this-to-a-random-secret-key'):
+            print(f'{key} must be set. Generate a secure value at https://www.random.org/passwords/?num=5&len=32&format=html&rnd=new', file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/docker-compose-coolify.yaml
+++ b/docker-compose-coolify.yaml
@@ -11,8 +11,8 @@ services:
       SERVICE_FQDN_APP: ${SERVICE_FQDN_APP}
       POSTGRES_DB:       ${POSTGRES_DB:-db}
       POSTGRES_USER:     ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-change-this-to-a-random-secret-key}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-<postgres_password>}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-<django_secret_key>}
       HIBP_API_KEY:      ${HIBP_API_KEY:-}
       DJANGO_DEBUG:      ${DJANGO_DEBUG:-false}
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,8 +6,8 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-db}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
-      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-<postgres_password>}
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY:-<django_secret_key>}
     ports:
       - "8000:8000"
     depends_on:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Validate environment before starting
+/usr/src/venvs/app-main/bin/python /usr/src/project/check_env.py
+
 
 # Ensure we can write to the STATIC_ROOT directory even if a
 # stale container image left it owned by root. This mirrors the


### PR DESCRIPTION
## Summary
- update `.env.example` with placeholders and new vars
- enforce placeholders in docker-compose files
- add environment validation script and call it in `entrypoint.sh`
- update README instructions

## Testing
- `python3 -m py_compile envutils.py generate_env.py check_env.py`
- `pip install -r .devcontainer/requirements.txt`
- `python3 manage.py test --noinput`

------
https://chatgpt.com/codex/tasks/task_e_685ab0372a08832c8a2587f658d2becc