### PR TITLE
Add configurable proxy domain

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -26,12 +26,12 @@ services:
 
     labels:
       - traefik.enable=true
-      - traefik.http.routers.pwnedproxy.rule=Host(`api.haveibeenpwned.security.ait.dtu.dk`)
+      - "traefik.http.routers.pwnedproxy.rule=Host(`$PWNED_PROXY_DOMAIN`)"
       - traefik.http.routers.pwnedproxy.entryPoints=websecure
       - traefik.http.routers.pwnedproxy.tls=true
       - traefik.http.routers.pwnedproxy.tls.certresolver=letsencrypt
       - traefik.http.services.pwnedproxy.loadbalancer.server.port=8000
-      - traefik.http.routers.pwnedproxy-insecure.rule=Host(`api.haveibeenpwned.security.ait.dtu.dk`)
+      - "traefik.http.routers.pwnedproxy-insecure.rule=Host(`$PWNED_PROXY_DOMAIN`)"
       - traefik.http.routers.pwnedproxy-insecure.entryPoints=web
       - traefik.http.routers.pwnedproxy-insecure.middlewares=pwnedproxy-https-redirect
       - traefik.http.middlewares.pwnedproxy-https-redirect.redirectscheme.scheme=https

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ DJANGO_SUPERUSER_USERNAME=
 DJANGO_SUPERUSER_PASSWORD=
 HIBP_API_KEY=
 SERVICE_FQDN_APP=
+PWNED_PROXY_DOMAIN=api.haveibeenpwned.security.ait.dtu.dk
 
 # Set to 'true' to enable Django debug mode
 DJANGO_DEBUG=false

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ docker compose up --build
 ```
 
 The Django application will be available on port **8000**. It accepts
-requests for `localhost`, `api.dtuaitsoc.ngrok.dev` and
-`api.haveibeenpwned.security.ait.dtu.dk` thanks to the `ALLOWED_HOSTS`
-configuration. On first start, migrations are applied and a
+requests for `localhost`, `api.dtuaitsoc.ngrok.dev` and the domain set via
+`PWNED_PROXY_DOMAIN` (defaulting to `api.haveibeenpwned.security.ait.dtu.dk`).
+On first start, migrations are applied and a
 superuser is created automatically. If the `.env` file was generated, all
 generated values including the admin credentials are printed and stored in that
 file so you can reuse them across restarts.
@@ -53,7 +53,8 @@ When deploying on platforms like Coolify you may receive a unique domain via
 the `SERVICE_FQDN_APP` environment variable. You can also supply additional
 hosts through `DJANGO_ALLOWED_HOSTS`. These values are automatically appended to
 the Django `ALLOWED_HOSTS` list so the application will accept requests for your
-custom domain.
+custom domain. The base domain used by Traefik and Django can be configured via
+`PWNED_PROXY_DOMAIN`.
 
 You can then log into the admin interface at
 `http://localhost:8000/admin/` (or via your ngrok domain) using the

--- a/app-main/pwned_proxy/settings.py
+++ b/app-main/pwned_proxy/settings.py
@@ -43,12 +43,16 @@ AZURE_AD_GRANT_TYPE = os.environ.get('AZURE_APP_AIT_SOC_GRAPH_VICRE_REGISTRATION
 _debug_env = os.environ.get("DJANGO_DEBUG", "false").lower()
 DEBUG = _debug_env in {"1", "true", "yes"}
 
+PWNED_PROXY_DOMAIN = os.environ.get(
+    "PWNED_PROXY_DOMAIN", "api.haveibeenpwned.security.ait.dtu.dk"
+)
+
 ALLOWED_HOSTS = [
     "localhost",
     "127.0.0.1",
     "dtuaitsoc.ngrok.dev",
     "api.dtuaitsoc.ngrok.dev",
-    "api.haveibeenpwned.security.ait.dtu.dk",
+    PWNED_PROXY_DOMAIN,
 ]
 
 # Allow additional hosts to be configured via environment variables.
@@ -193,7 +197,7 @@ CSRF_TRUSTED_ORIGINS = [
     "http://localhost:8000",
     "http://127.0.0.1:8000",
     # add other domains if necessary
-    "https://api.haveibeenpwned.security.ait.dtu.dk",
+    f"https://{PWNED_PROXY_DOMAIN}",
 ]
 
 CORS_ALLOW_ALL_ORIGINS = True


### PR DESCRIPTION
## Summary
- add `PWNED_PROXY_DOMAIN` environment variable
- reference the variable in settings and Docker Compose
- document usage in README

## Testing
- `pip install -r .devcontainer/requirements.txt`
- `PYTHONPATH=app-main DJANGO_SETTINGS_MODULE=pwned_proxy.settings python manage.py test api`

------
https://chatgpt.com/codex/tasks/task_e_686b9ee67200832ca4e377660be06f39